### PR TITLE
Add Gogs SCM driver

### DIFF
--- a/src/scm/driver/gogs/constants.rs
+++ b/src/scm/driver/gogs/constants.rs
@@ -1,0 +1,23 @@
+// Copyright (c) The Amphitheatre Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub const GOGS_ENDPOINT: &str = "https://gogs.io";
+
+// REST API paths (see https://gogs.io/docs/api)
+pub const GOGS_PATH_CONTENTS: &str = "/api/v1/repos/{repo}/contents/{file}";
+pub const GOGS_PATH_BRANCHES: &str = "/api/v1/repos/{repo}/branches";
+pub const GOGS_PATH_TAGS: &str = "/api/v1/repos/{repo}/tags";
+pub const GOGS_PATH_COMMITS: &str = "/api/v1/repos/{repo}/git/commits/{reference}";
+pub const GOGS_PATH_GIT_TREES: &str = "/api/v1/repos/{repo}/git/trees/{tree_sha}";
+pub const GOGS_PATH_REPOS: &str = "/api/v1/repos/{repo}";

--- a/src/scm/driver/gogs/content.rs
+++ b/src/scm/driver/gogs/content.rs
@@ -1,0 +1,125 @@
+// Copyright (c) The Amphitheatre Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use data_encoding::BASE64_MIME as BASE64;
+use serde::{Deserialize, Serialize};
+
+use super::constants::GOGS_PATH_CONTENTS;
+use crate::http::{endpoint::Endpoint, Client};
+use crate::scm::content::{Content, ContentService, File};
+use crate::scm::errors::SCMError;
+
+pub struct GogsContentService {
+    pub client: Client,
+}
+
+#[async_trait]
+impl ContentService for GogsContentService {
+    /// Gets the contents of a file in a repository.
+    ///
+    /// Docs: https://gogs.io/docs/api
+    /// Example: https://gogs.io/api/v1/repos/gogs/gogs/contents/README.md
+    async fn find(&self, repo: &str, file: &str, reference: &str) -> Result<Content, SCMError> {
+        let path = GOGS_PATH_CONTENTS.replace("{repo}", repo).replace("{file}", file);
+        let options = HashMap::from([("ref".to_string(), reference.to_string())]);
+        let res = self
+            .client
+            .get::<GogsContent>(&path, Some(options))
+            .await
+            .map_err(SCMError::ClientError)?;
+
+        if let Some(content) = res.data {
+            Ok(content.try_into().map_err(SCMError::DecodeError)?)
+        } else {
+            Err(SCMError::NotFound(path))
+        }
+    }
+
+    /// Gets the file list of a directory in a repository.
+    ///
+    /// Docs: https://gogs.io/docs/api
+    /// Example: https://gogs.io/api/v1/repos/gogs/gogs/contents
+    async fn list(&self, repo: &str, path: &str, reference: &str) -> Result<Vec<File>, SCMError> {
+        let path = GOGS_PATH_CONTENTS.replace("{repo}", repo).replace("{file}", path);
+        let options = HashMap::from([("ref".to_string(), reference.to_string())]);
+        let res = self
+            .client
+            .get::<Vec<GogsFile>>(&path, Some(options))
+            .await
+            .map_err(SCMError::ClientError)?;
+
+        if let Some(list) = res.data {
+            return Ok(list.iter().map(|v| v.into()).collect());
+        }
+
+        Ok(vec![])
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GogsContent {
+    pub name: String,
+    pub path: String,
+    pub sha: String,
+    pub content: String,
+    #[serde(rename = "type")]
+    pub kind: String,
+}
+
+impl TryFrom<GogsContent> for Content {
+    type Error = data_encoding::DecodeError;
+
+    fn try_from(val: GogsContent) -> Result<Self, Self::Error> {
+        Ok(Self {
+            path: val.path,
+            data: BASE64.decode(val.content.as_bytes())?,
+            // the sha returned for gogs rest api is the commit sha, not the blob sha
+            sha: val.sha.clone(),
+            blob_id: val.sha,
+        })
+    }
+}
+
+impl Endpoint for GogsContent {
+    type Output = GogsContent;
+}
+
+/// represents a file in a repository.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GogsFile {
+    pub name: String,
+    pub path: String,
+    pub sha: String,
+    #[serde(rename = "type")]
+    pub kind: String,
+}
+
+impl From<&GogsFile> for File {
+    fn from(val: &GogsFile) -> Self {
+        Self {
+            name: val.name.clone(),
+            path: val.path.clone(),
+            sha: val.sha.clone(),
+            blob_id: val.sha.clone(),
+            kind: val.kind.clone(),
+        }
+    }
+}
+
+impl Endpoint for Vec<GogsFile> {
+    type Output = Vec<GogsFile>;
+}

--- a/src/scm/driver/gogs/driver.rs
+++ b/src/scm/driver/gogs/driver.rs
@@ -1,0 +1,61 @@
+// Copyright (c) The Amphitheatre Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::content::GogsContentService;
+use super::git::GogsService;
+use super::repo::GogsRepoService;
+use crate::http::Client;
+use crate::scm::content::ContentService;
+use crate::scm::driver::DriverTrait;
+use crate::scm::git::GitService;
+use crate::scm::repo::RepositoryService;
+
+pub struct GogsDriver {
+    pub client: Client,
+}
+
+impl DriverTrait for GogsDriver {
+    fn contents(&self) -> Box<dyn ContentService> {
+        Box::new(GogsContentService {
+            client: self.client.clone(),
+        })
+    }
+
+    fn git(&self) -> Box<dyn GitService> {
+        Box::new(GogsService {
+            client: self.client.clone(),
+        })
+    }
+
+    fn repositories(&self) -> Box<dyn RepositoryService> {
+        Box::new(GogsRepoService {
+            client: self.client.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::scm::driver::{gogs, DriverTrait};
+
+    #[test]
+    fn return_git_service() {
+        gogs::default().unwrap().git();
+    }
+
+    #[test]
+    fn return_repo_service() {
+        gogs::default().unwrap().repositories();
+    }
+}

--- a/src/scm/driver/gogs/git.rs
+++ b/src/scm/driver/gogs/git.rs
@@ -1,0 +1,246 @@
+// Copyright (c) The Amphitheatre Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use super::constants::{GOGS_PATH_BRANCHES, GOGS_PATH_COMMITS, GOGS_PATH_GIT_TREES, GOGS_PATH_TAGS};
+use super::utils::convert_list_options;
+use super::GogsFile;
+use crate::http::{endpoint::Endpoint, Client};
+use crate::scm::client::ListOptions;
+use crate::scm::errors::SCMError;
+use crate::scm::git::{Commit, GitService, Reference, Signature, Tree, TreeEntry};
+use crate::scm::utils;
+
+pub struct GogsService {
+    pub client: Client,
+}
+
+#[async_trait]
+impl GitService for GogsService {
+    /// Returns a list of branches for the specified repository.
+    ///
+    /// Docs: https://gogs.io/docs/api
+    /// Example: https://gogs.io/api/v1/repos/gogs/gogs/branches
+    async fn list_branches(&self, repo: &str, opts: ListOptions) -> Result<Vec<Reference>, SCMError> {
+        let path = GOGS_PATH_BRANCHES.replace("{repo}", repo);
+        let options = Some(convert_list_options(opts));
+        let res = self
+            .client
+            .get::<Vec<GogsBranch>>(&path, options)
+            .await
+            .map_err(SCMError::ClientError)?;
+
+        if let Some(branches) = res.data {
+            return Ok(branches.iter().map(|v| v.into()).collect());
+        }
+
+        Ok(vec![])
+    }
+
+    /// Returns a list of tags for the specified repository.
+    ///
+    /// Docs: https://gogs.io/docs/api
+    /// Example: https://gogs.io/api/v1/repos/gogs/gogs/tags
+    async fn list_tags(&self, repo: &str, opts: ListOptions) -> Result<Vec<Reference>, SCMError> {
+        let path = GOGS_PATH_TAGS.replace("{repo}", repo);
+        let options = Some(convert_list_options(opts));
+        let res = self
+            .client
+            .get::<Vec<GogsBranch>>(&path, options)
+            .await
+            .map_err(SCMError::ClientError)?;
+
+        if let Some(tags) = res.data {
+            return Ok(tags.iter().map(|v| v.into()).collect());
+        }
+
+        Ok(vec![])
+    }
+
+    /// Returns the contents of a single commit reference.
+    ///
+    /// Docs: https://gogs.io/docs/api
+    /// Example: https://gogs.io/api/v1/repos/gogs/gogs/git/commits/4b28b80e1c5f8c0c5c7c5c5f5c5c5c5c5c5c5c5c
+    async fn find_commit(&self, repo: &str, reference: &str) -> Result<Option<Commit>, SCMError> {
+        let path = GOGS_PATH_COMMITS
+            .replace("{repo}", repo)
+            .replace("{reference}", reference);
+        let res = self
+            .client
+            .get::<GogsCommit>(&path, None)
+            .await
+            .map_err(SCMError::ClientError)?;
+
+        Ok(res.data.map(|v| v.into()))
+    }
+
+    /// Returns a single tree using the SHA1 value or ref name for that tree.
+    ///
+    /// Docs: https://gogs.io/docs/api
+    /// Example: https://gogs.io/api/v1/repos/gogs/gogs/git/trees/master
+    async fn get_tree(
+        &self,
+        repo: &str,
+        tree_sha: &str,
+        recursive: Option<bool>,
+    ) -> Result<Option<Tree>, SCMError> {
+        let path = GOGS_PATH_GIT_TREES
+            .replace("{repo}", repo)
+            .replace("{tree_sha}", tree_sha);
+        let options = recursive
+            .map(|r| Some(HashMap::from([("recursive".to_string(), r.to_string())])))
+            .unwrap_or_default();
+        let res = self
+            .client
+            .get::<GogsTree>(&path, options)
+            .await
+            .map_err(SCMError::ClientError)?;
+
+        Ok(res.data.map(|v| v.into()))
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GogsBranch {
+    pub name: String,
+    pub commit: GogsSimpleCommit,
+    pub protected: bool,
+}
+
+impl From<&GogsBranch> for Reference {
+    fn from(val: &GogsBranch) -> Self {
+        Self {
+            name: utils::trim_ref(&val.name),
+            path: utils::expand_ref(&val.name, "refs/heads/"),
+            sha: val.commit.sha.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GogsSimpleCommit {
+    // Gogs uses "id" for the commit sha in some payloads, and "sha" in others,
+    // so accept both.
+    #[serde(alias = "id")]
+    pub sha: String,
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GogsCommit {
+    pub sha: String,
+    pub html_url: Option<String>,
+    pub commit: GogsCommitObject,
+    pub author: Option<GogsAuthor>,
+    pub committer: Option<GogsAuthor>,
+    pub files: Vec<GogsFile>,
+}
+
+impl From<GogsCommit> for Commit {
+    fn from(val: GogsCommit) -> Self {
+        Self {
+            sha: val.sha,
+            message: val.commit.message.unwrap_or_default(),
+            author: Signature {
+                name: val.commit.author.name,
+                email: val.commit.author.email,
+                date: val.commit.author.date,
+                login: Some(val.author.clone().unwrap_or_default().login),
+                avatar: Some(val.author.clone().unwrap_or_default().avatar_url),
+            },
+            committer: Signature {
+                name: val.commit.committer.name,
+                email: val.commit.committer.email,
+                date: val.commit.committer.date,
+                login: Some(val.committer.clone().unwrap_or_default().login),
+                avatar: Some(val.committer.clone().unwrap_or_default().avatar_url),
+            },
+            link: val.html_url.unwrap_or_default(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GogsCommitObject {
+    pub author: GogsCommitObjectAuthor,
+    pub committer: GogsCommitObjectAuthor,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GogsCommitObjectAuthor {
+    pub name: String,
+    pub email: String,
+    pub date: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+pub struct GogsAuthor {
+    pub avatar_url: String,
+    pub login: String,
+}
+
+impl Endpoint for Vec<GogsBranch> {
+    type Output = Vec<GogsBranch>;
+}
+
+impl Endpoint for GogsCommit {
+    type Output = GogsCommit;
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GogsTree {
+    pub sha: String,
+    pub tree: Vec<GogsTreeEntry>,
+    pub truncated: bool,
+}
+
+impl From<GogsTree> for Tree {
+    fn from(val: GogsTree) -> Self {
+        Self {
+            sha: val.sha,
+            tree: val.tree.iter().map(|v| v.into()).collect(),
+            truncated: val.truncated,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GogsTreeEntry {
+    pub mode: String,
+    pub path: String,
+    pub sha: String,
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub size: Option<u64>,
+}
+
+impl From<&GogsTreeEntry> for TreeEntry {
+    fn from(val: &GogsTreeEntry) -> Self {
+        Self {
+            mode: val.mode.clone(),
+            path: val.path.clone(),
+            sha: val.sha.clone(),
+            kind: val.kind.clone(),
+            size: val.size,
+        }
+    }
+}
+
+impl Endpoint for GogsTree {
+    type Output = GogsTree;
+}

--- a/src/scm/driver/gogs/mod.rs
+++ b/src/scm/driver/gogs/mod.rs
@@ -1,0 +1,66 @@
+// Copyright (c) The Amphitheatre Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod constants;
+pub mod content;
+pub mod driver;
+pub mod git;
+pub mod pr;
+pub mod repo;
+mod utils;
+
+use self::constants::GOGS_ENDPOINT;
+use self::pr::GogsFile;
+use super::Driver;
+use crate::http::Client;
+use crate::scm::driver::gogs::driver::GogsDriver;
+use crate::scm::errors::SCMError;
+
+/// Returns a new Gogs driver using the default gogs.io address.
+#[inline]
+pub fn default() -> Result<Driver, SCMError> {
+    from(Client::new(GOGS_ENDPOINT, None).map_err(SCMError::ClientError)?)
+}
+
+/// Returns a new Gogs driver.
+#[inline]
+pub fn new(url: &str, token: Option<String>) -> Result<Driver, SCMError> {
+    from(Client::new(url, token).map_err(SCMError::ClientError)?)
+}
+
+/// Returns a new Gogs driver using the given client.
+pub fn from(client: Client) -> Result<Driver, SCMError> {
+    Ok(Driver::Gogs(GogsDriver { client }))
+}
+
+#[cfg(test)]
+mod test {
+    use super::constants::GOGS_ENDPOINT;
+    use crate::{http::Client, scm::driver::gogs};
+
+    #[test]
+    fn create_gogs_driver() {
+        let _driver = gogs::default();
+    }
+
+    #[test]
+    fn create_gogs_driver_from_client() {
+        let _driver = gogs::from(Client::new(GOGS_ENDPOINT, None).unwrap());
+    }
+
+    #[test]
+    fn create_gogs_enterprise_driver() {
+        let _driver = gogs::new("https://gogs.company.com", None);
+    }
+}

--- a/src/scm/driver/gogs/pr.rs
+++ b/src/scm/driver/gogs/pr.rs
@@ -1,0 +1,25 @@
+// Copyright (c) The Amphitheatre Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GogsFile {
+    pub sha: String,
+    pub filename: String,
+    pub status: String,
+    pub additions: i32,
+    pub deletions: i32,
+    pub changes: i32,
+}

--- a/src/scm/driver/gogs/repo.rs
+++ b/src/scm/driver/gogs/repo.rs
@@ -1,0 +1,90 @@
+// Copyright (c) The Amphitheatre Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::http::{endpoint::Endpoint, Client};
+use crate::scm::errors::SCMError;
+use crate::scm::repo::{Repository, RepositoryService};
+
+use super::constants::GOGS_PATH_REPOS;
+
+pub struct GogsRepoService {
+    pub client: Client,
+}
+
+#[async_trait]
+impl RepositoryService for GogsRepoService {
+    /// Returns a repository by name.
+    ///
+    /// Docs: https://gogs.io/docs/api
+    /// Example: https://gogs.io/api/v1/repos/gogs/gogs
+    async fn find(&self, repo: &str) -> Result<Option<Repository>, SCMError> {
+        let path = GOGS_PATH_REPOS.replace("{repo}", repo);
+        let res = self
+            .client
+            .get::<GogsRepository>(&path, None)
+            .await
+            .map_err(SCMError::ClientError)?;
+
+        Ok(res.data.map(|v| v.into()))
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GogsRepository {
+    pub id: u64,
+    pub name: String,
+    pub owner: Option<GogsOwner>,
+    pub html_url: String,
+    pub archived: bool,
+    pub visibility: String,
+    pub clone_url: Option<String>,
+    pub ssh_url: Option<String>,
+    pub default_branch: String,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Default)]
+pub struct GogsOwner {
+    pub id: u64,
+    pub login: String,
+    pub avatar_url: String,
+}
+
+impl From<GogsRepository> for Repository {
+    fn from(val: GogsRepository) -> Self {
+        Self {
+            id: val.id.to_string(),
+            namespace: val.owner.unwrap_or_default().login,
+            name: val.name,
+            branch: val.default_branch,
+            archived: val.archived,
+            visibility: val.visibility.into(),
+            clone: val.clone_url.unwrap_or_default(),
+            clone_ssh: val.ssh_url.unwrap_or_default(),
+            link: val.html_url,
+            created: val.created_at.unwrap_or_default(),
+            updated: val.updated_at.unwrap_or_default(),
+            description: val.description,
+        }
+    }
+}
+
+impl Endpoint for GogsRepository {
+    type Output = GogsRepository;
+}

--- a/src/scm/driver/gogs/utils.rs
+++ b/src/scm/driver/gogs/utils.rs
@@ -1,0 +1,30 @@
+// Copyright (c) The Amphitheatre Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use crate::scm::client::ListOptions;
+
+pub fn convert_list_options(opts: ListOptions) -> HashMap<String, String> {
+    let mut options: HashMap<String, String> = HashMap::new();
+
+    if opts.page != 0 {
+        options.insert(String::from("page"), opts.page.to_string());
+    }
+    if opts.size != 0 {
+        options.insert(String::from("per_page"), opts.size.to_string());
+    }
+
+    options
+}

--- a/src/scm/driver/mod.rs
+++ b/src/scm/driver/mod.rs
@@ -15,6 +15,7 @@
 pub mod atomgit;
 pub mod github;
 pub mod gitlab;
+pub mod gogs;
 
 use super::errors::SCMError;
 use crate::config::RepositoryCredential;
@@ -28,6 +29,7 @@ pub enum Driver {
     Github(github::driver::GithubDriver),
     Gitlab(gitlab::driver::GitlabDriver),
     AtomGit(atomgit::driver::AtomGitDriver),
+    Gogs(gogs::driver::GogsDriver),
 }
 
 /// Defines the methods that a SCM driver must implement.
@@ -43,6 +45,7 @@ impl DriverTrait for Driver {
             Driver::Github(driver) => driver.contents(),
             Driver::Gitlab(driver) => driver.contents(),
             Driver::AtomGit(driver) => driver.contents(),
+            Driver::Gogs(driver) => driver.contents(),
         }
     }
 
@@ -51,6 +54,7 @@ impl DriverTrait for Driver {
             Driver::Github(driver) => driver.git(),
             Driver::Gitlab(driver) => driver.git(),
             Driver::AtomGit(driver) => driver.git(),
+            Driver::Gogs(driver) => driver.git(),
         }
     }
 
@@ -59,6 +63,7 @@ impl DriverTrait for Driver {
             Driver::Github(driver) => driver.repositories(),
             Driver::Gitlab(driver) => driver.repositories(),
             Driver::AtomGit(driver) => driver.repositories(),
+            Driver::Gogs(driver) => driver.repositories(),
         }
     }
 }
@@ -71,6 +76,7 @@ impl TryFrom<&RepositoryCredential> for Driver {
             "github" => Ok(github::new(&credential.server, credential.token.clone())?),
             "gitlab" => Ok(gitlab::new(&credential.server, credential.token.clone())?),
             "atomgit" => Ok(atomgit::new(&credential.server, credential.token.clone())?),
+            "gogs" => Ok(gogs::new(&credential.server, credential.token.clone())?),
             _ => Err(SCMError::UnknownDriver(credential.driver.to_string())),
         }
     }
@@ -85,6 +91,7 @@ impl TryFrom<&str> for Driver {
             "github.com" => Ok(github::default()?),
             "gitlab.com" => Ok(gitlab::default()?),
             "atomgit.com" => Ok(atomgit::default()?),
+            "gogs.io" => Ok(gogs::default()?),
             _ => Err(SCMError::UnknownDriver(url.to_string())),
         }
     }


### PR DESCRIPTION
Adds a new Gogs SCM driver mirroring the existing atomgit driver (content, git, repo services) and wires it into the Driver enum. Closes #5